### PR TITLE
Vim Mode 4 - Core functionality for Vim Mode

### DIFF
--- a/src/ts/core/common/dom.ts
+++ b/src/ts/core/common/dom.ts
@@ -55,7 +55,10 @@ export function getInputEvent() {
     })
 }
 
-export const isElementVisible = (element: Element) => {
+export const isElementVisible = (element: Element | null): boolean => {
+    if (!element) {
+        return false
+    }
     const {x, y} = element.getBoundingClientRect()
     return x >= 0 && y >= 0 && x <= window.innerWidth && y <= window.innerHeight
 }

--- a/src/ts/core/common/mutation-observer.ts
+++ b/src/ts/core/common/mutation-observer.ts
@@ -1,6 +1,6 @@
 import {assumeExists} from 'src/core/common/assert'
 
-type DisconnectFn = () => void
+export type DisconnectFn = () => void
 
 export const onSelectorChange = (selector: string, handleChange: (changedElement: HTMLElement) => void): DisconnectFn =>
     observeElement(assumeExists(document.querySelector(selector)) as HTMLElement, handleChange)
@@ -23,18 +23,27 @@ const observeElement = (
     return () => waitForLoad.disconnect()
 }
 
-export const waitForSelectorToExist = (selector: string, observeInside: HTMLElement = document.body) => {
-    if (observeInside.querySelector(selector)) {
-        return Promise.resolve()
-    }
-
+/**
+ * @return A promise of the element matching the selector
+ */
+export const waitForSelectorToExist = (selector: string, observeInside: HTMLElement = document.body): Promise<HTMLElement> => {
     return new Promise(resolve => {
+        const resolveIfElementExists = () => {
+            const element = observeInside.querySelector(selector) as HTMLElement;
+            if (element) {
+                resolve(element)
+                return true;
+            }
+            return false;
+        }
+
+        resolveIfElementExists()
+
         const disconnect = observeElement(
             observeInside,
             () => {
-                if (observeInside.querySelector(selector)) {
+                if (resolveIfElementExists()) {
                     disconnect()
-                    resolve()
                 }
             },
             true

--- a/src/ts/core/features/index.ts
+++ b/src/ts/core/features/index.ts
@@ -6,6 +6,7 @@ import {config as incDec} from './inc-dec-value'
 import {config as customCss} from './custom-css'
 import {config as srs} from '../srs/srs'
 import {config as blockManipulation} from './block-manipulation'
+import {config as vimMode} from './vim-mode'
 import {config as estimate} from './estimates'
 import {config as navigation} from './navigation'
 import {config as livePreview} from './livePreview'
@@ -20,6 +21,7 @@ export const Features = {
         incDec, // prettier
         srs,
         blockManipulation,
+        vimMode,
         estimate,
         customCss,
         navigation,

--- a/src/ts/core/features/vim-mode/commands/block-manipulation-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/block-manipulation-commands.ts
@@ -1,0 +1,18 @@
+import {nimap} from 'src/core/features/vim-mode/vim'
+import {Keyboard} from 'src/core/common/keyboard'
+import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+
+const moveBlockUp = async () => {
+    RoamBlock.selected().edit()
+    await Keyboard.simulateKey(Keyboard.UP_ARROW, 0, {metaKey: true, shiftKey: true})
+}
+
+const moveBlockDown = async () => {
+    RoamBlock.selected().edit()
+    await Keyboard.simulateKey(Keyboard.DOWN_ARROW, 0, {metaKey: true, shiftKey: true})
+}
+
+export const BlockManipulationCommands = [
+    nimap('command+shift+k', 'Move Block Up', moveBlockUp),
+    nimap('command+shift+j', 'Move Block Down', moveBlockDown),
+]

--- a/src/ts/core/features/vim-mode/commands/clipboard-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/clipboard-commands.ts
@@ -1,0 +1,59 @@
+import {delay} from 'src/core/common/async'
+import {Mode, nmap, nvmap, returnToNormalMode, RoamVim} from 'src/core/features/vim-mode/vim'
+import {insertBlockAfter} from 'src/core/features/vim-mode/commands/insert-commands'
+import {Roam} from 'src/core/roam/roam'
+import {copyBlockEmbed, copyBlockReference} from 'src/core/roam/block'
+import {RoamPanel} from 'src/core/features/vim-mode/roam/roam-panel'
+import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+
+const cutAndGoBackToNormal = async () => {
+    document.execCommand('cut')
+    // Wait for the block to disappear, double check that a block is still selected
+    // Deleting the first line can lead to no previous block existing to select
+    await delay(0)
+    await returnToNormalMode()
+}
+
+const paste = async () => {
+    await insertBlockAfter()
+    document.execCommand('paste')
+    await returnToNormalMode()
+}
+
+const pasteBefore = async () => {
+    await RoamVim.jumpBlocksInFocusedPanel(-1)
+    await insertBlockAfter()
+    document.execCommand('paste')
+    await returnToNormalMode()
+}
+
+const copySelectedBlock = async (mode: Mode) => {
+    if (mode === Mode.NORMAL) {
+        await Roam.highlight(RoamBlock.selected().element)
+    }
+    document.execCommand('copy')
+    await returnToNormalMode()
+}
+
+const copySelectedBlockReference = () => copyBlockReference(RoamPanel.selected().selectedBlockId)
+
+const copySelectedBlockEmbed = () => copyBlockEmbed(RoamPanel.selected().selectedBlockId)
+
+const enterOrCutInVisualMode = async (mode: Mode) => {
+    if (mode === Mode.NORMAL) {
+        return Roam.highlight(RoamBlock.selected().element)
+    }
+    await cutAndGoBackToNormal()
+}
+
+export const ClipboardCommands = [
+    nmap('p', 'Paste', paste),
+    nmap('shift+p', 'Paste Before', pasteBefore),
+    nvmap('y', 'Copy', copySelectedBlock),
+    nvmap('alt+y', 'Copy Block Reference', copySelectedBlockReference),
+    nvmap('shift+y', 'Copy Block Embed', copySelectedBlockEmbed),
+    // mapping 'd d' and 'd' conflict with each other.
+    // replicate the behavior of `d d` by entering visual, and then cutting
+    // this gives more feedback in the UX anyways
+    nvmap('d', 'Enter Visual Mode / Cut in Visual Mode', enterOrCutInVisualMode),
+]

--- a/src/ts/core/features/vim-mode/commands/history-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/history-commands.ts
@@ -1,0 +1,15 @@
+import {nmap, returnToNormalMode} from 'src/core/features/vim-mode/vim'
+import {Keyboard} from 'src/core/common/keyboard'
+import {KEY_TO_CODE} from 'src/core/common/keycodes'
+
+const undo = async () => {
+    await Keyboard.simulateKey(KEY_TO_CODE['z'], 0, {key: 'z', metaKey: true})
+    await returnToNormalMode()
+}
+
+const redo = async () => {
+    await Keyboard.simulateKey(KEY_TO_CODE['z'], 0, {key: 'z', shiftKey: true, metaKey: true})
+    await returnToNormalMode()
+}
+
+export const HistoryCommands = [nmap('u', 'Undo', undo), nmap('ctrl+r', 'Redo', redo)]

--- a/src/ts/core/features/vim-mode/commands/insert-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/insert-commands.ts
@@ -1,0 +1,32 @@
+import {Roam} from 'src/core/roam/roam'
+import {nmap} from 'src/core/features/vim-mode/vim'
+import {Keyboard} from 'src/core/common/keyboard'
+import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+
+export const insertBlockAfter = async () => {
+    await Roam.activateBlock(RoamBlock.selected().element)
+    await Roam.createBlockBelow()
+}
+
+const editBlock = async () => {
+    await Roam.activateBlock(RoamBlock.selected().element)
+    Roam.moveCursorToStart()
+}
+
+const editBlockFromEnd = async () => {
+    await Roam.activateBlock(RoamBlock.selected().element)
+    Roam.moveCursorToEnd()
+}
+
+const insertBlockBefore = async () => {
+    await Roam.activateBlock(RoamBlock.selected().element)
+    await Roam.moveCursorToStart()
+    await Keyboard.pressEnter()
+}
+
+export const InsertCommands = [
+    nmap('i', 'Click Selection', editBlock),
+    nmap('a', 'Click Selection and Go-to End of Line', editBlockFromEnd),
+    nmap('shift+o', 'Insert Block Before', insertBlockBefore),
+    nmap('o', 'Insert Block After', insertBlockAfter),
+]

--- a/src/ts/core/features/vim-mode/commands/navigation-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/navigation-commands.ts
@@ -1,0 +1,24 @@
+import {nmap, nvmap, RoamVim} from 'src/core/features/vim-mode/vim'
+import {RoamPanel} from 'src/core/features/vim-mode/roam/roam-panel'
+
+const selectFirstBlock = () => {
+    const panel = RoamPanel.selected()
+    panel.selectBlock(panel.firstBlock().id)
+}
+
+const selectLastBlock = () => {
+    const panel = RoamPanel.selected()
+    panel.selectBlock(panel.lastBlock().id)
+}
+
+export const NavigationCommands = [
+    nvmap('k', 'Select Block Up', () => RoamVim.jumpBlocksInFocusedPanel(-1)),
+    nvmap('j', 'Select Block Down', () => RoamVim.jumpBlocksInFocusedPanel(1)),
+    nmap('g g', 'Select First Block', selectFirstBlock),
+    nmap('shift+g', 'Select Last Block', selectLastBlock),
+    nmap('ctrl+u', 'Select Many Blocks Up', () => RoamVim.jumpBlocksInFocusedPanel(-8)),
+    nmap('ctrl+d', 'Select Many Blocks Down', () => RoamVim.jumpBlocksInFocusedPanel(8)),
+    nvmap('ctrl+y', 'Scroll Up', () => RoamPanel.selected().scrollAndReselectBlockToStayVisible(-50)),
+    // Avoid insert mode, to allow native ctrl-e to go to end of line
+    nvmap('ctrl+e', 'Scroll Down', () => RoamPanel.selected().scrollAndReselectBlockToStayVisible(50)),
+]

--- a/src/ts/core/features/vim-mode/commands/panel-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/panel-commands.ts
@@ -1,0 +1,21 @@
+import {map, nmap} from 'src/core/features/vim-mode/vim'
+import {Selectors} from 'src/core/roam/selectors'
+import {Mouse} from 'src/core/common/mouse'
+import {RoamPanel} from 'src/core/features/vim-mode/roam/roam-panel'
+import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+
+const closeSidebarPage = () => {
+    const block = RoamBlock.selected().element
+    const pageContainer = block.closest(`${Selectors.sidebarContent} > div`)
+    const closeButton = pageContainer?.querySelector(Selectors.closeButton)
+    if (closeButton) {
+        Mouse.leftClick(closeButton as HTMLElement)
+    }
+}
+
+export const PanelCommands = [
+    // Need to wrap in function to preserve the `this` reference inside of RoamPanel
+    nmap('h', 'Select Panel Left', () => RoamPanel.previousPanel().select()),
+    nmap('l', 'Select Panel Right', () => RoamPanel.nextPanel().select()),
+    map('ctrl+w', 'Close Page in Side Bar', closeSidebarPage),
+]

--- a/src/ts/core/features/vim-mode/commands/visual-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/visual-commands.ts
@@ -1,0 +1,26 @@
+import {Mode, nmap, nvmap} from 'src/core/features/vim-mode/vim'
+import {Roam} from 'src/core/roam/roam'
+import {Keyboard} from 'src/core/common/keyboard'
+import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+
+const highlightSelectedBlock = () => Roam.highlight(RoamBlock.selected().element)
+
+const growHighlightUp = async (mode: Mode) => {
+    if (mode === Mode.NORMAL) {
+        await Roam.highlight(RoamBlock.selected().element)
+    }
+    await Keyboard.simulateKey(Keyboard.UP_ARROW, 0, {shiftKey: true})
+}
+
+const growHighlightDown = async (mode: Mode) => {
+    if (mode === Mode.NORMAL) {
+        await Roam.highlight(RoamBlock.selected().element)
+    }
+    await Keyboard.simulateKey(Keyboard.DOWN_ARROW, 0, {shiftKey: true})
+}
+
+export const VisualCommands = [
+    nmap('v', 'Enter Visual Mode', highlightSelectedBlock),
+    nvmap('shift+k', 'Grow Selection Up', growHighlightUp),
+    nvmap('shift+j', 'Grow Selection Down', growHighlightDown),
+]

--- a/src/ts/core/features/vim-mode/index.ts
+++ b/src/ts/core/features/vim-mode/index.ts
@@ -1,0 +1,35 @@
+import {initializeBlockNavigationMode} from 'src/core/features/vim-mode/vim-init'
+import {map, nmap, returnToNormalMode} from 'src/core/features/vim-mode/vim'
+import {Feature, Settings} from 'src/core/settings'
+import {NavigationCommands} from 'src/core/features/vim-mode/commands/navigation-commands'
+import {HistoryCommands} from 'src/core/features/vim-mode/commands/history-commands'
+import {InsertCommands} from 'src/core/features/vim-mode/commands/insert-commands'
+import {ClipboardCommands} from 'src/core/features/vim-mode/commands/clipboard-commands'
+import {PanelCommands} from 'src/core/features/vim-mode/commands/panel-commands'
+import {VisualCommands} from 'src/core/features/vim-mode/commands/visual-commands'
+import {BlockManipulationCommands} from 'src/core/features/vim-mode/commands/block-manipulation-commands'
+import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+
+export const config: Feature = {
+    id: 'block_navigation_mode',
+    name: 'Vim-like Block Navigation',
+    warning: 'Experimental; Intrusive, may interfere with your regular workflow',
+    enabledByDefault: false,
+    settings: [
+        map('Escape', 'Exit to Normal Mode', returnToNormalMode),
+        nmap('z', 'Toggle Fold Block', () => RoamBlock.selected().toggleFold()),
+        ...NavigationCommands,
+        ...PanelCommands,
+        ...InsertCommands,
+        ...HistoryCommands,
+        ...ClipboardCommands,
+        ...VisualCommands,
+        ...BlockManipulationCommands,
+    ],
+}
+
+Settings.isActive('block_navigation_mode').then(active => {
+    if (active) {
+        initializeBlockNavigationMode()
+    }
+})

--- a/src/ts/core/features/vim-mode/roam/roam-block.ts
+++ b/src/ts/core/features/vim-mode/roam/roam-block.ts
@@ -1,0 +1,37 @@
+import {assumeExists} from 'src/core/common/assert'
+import {RoamPanel} from 'src/core/features/vim-mode/roam/roam-panel'
+import {Roam} from 'src/core/roam/roam'
+
+export type BlockId = string
+export type BlockElement = HTMLElement
+
+/**
+ * The generically reusable parts of this should probably move to core/roam
+ */
+export class RoamBlock {
+    private blockId: BlockId
+
+    constructor(blockId: BlockId) {
+        this.blockId = blockId
+    }
+
+    get element(): BlockElement {
+        return assumeExists(document.getElementById(this.blockId))
+    }
+
+    async edit() {
+        await Roam.activateBlock(this.element)
+    }
+
+    async toggleFold() {
+        await Roam.toggleFoldBlock(this.element)
+    }
+
+    static get(blockId: BlockId): RoamBlock {
+        return new RoamBlock(blockId)
+    }
+
+    static selected(): RoamBlock {
+        return RoamPanel.selected().selectedBlock()
+    }
+}

--- a/src/ts/core/features/vim-mode/roam/roam-event.ts
+++ b/src/ts/core/features/vim-mode/roam/roam-event.ts
@@ -1,0 +1,70 @@
+import {BlockElement} from 'src/core/features/vim-mode/roam/roam-block'
+import {DisconnectFn, onSelectorChange, waitForSelectorToExist} from 'src/core/common/mutation-observer'
+import {Selectors} from 'src/core/roam/selectors'
+import {assumeExists} from 'src/core/common/assert'
+
+const onBlockEvent = (eventType: string, handler: (element: BlockElement) => void) => {
+    const handleBlockEvent = (event: Event) => {
+        const element = event.target as BlockElement
+        if (element.classList.contains('rm-block-input')) {
+            handler(element)
+        }
+    }
+    document.addEventListener(eventType, handleBlockEvent)
+    return () => document.removeEventListener(eventType, handleBlockEvent)
+}
+
+/**
+ * Various helpers for detecting user actions
+ *
+ * The generically reusable parts of this should probably move to core/roam
+ */
+export const RoamEvent = {
+    // Triggers when the sidebar is shown or hidden
+    onSidebarToggle(handler: (isSideBarShowing: boolean) => void): DisconnectFn {
+        return onSelectorChange(Selectors.sidebar, () => {
+            const isSidebarShowing = !!document.querySelector(Selectors.sidebarContent)
+            handler(isSidebarShowing)
+        })
+    },
+
+    // Triggers when opening or closing an article in the sidebar
+    onSidebarChange(handler: () => void): DisconnectFn {
+        let stopObserving = () => {}
+        return RoamEvent.onSidebarToggle(isRightPanelOn => {
+            if (isRightPanelOn) {
+                stopObserving = onSelectorChange(Selectors.sidebarContent, handler)
+            } else {
+                stopObserving()
+            }
+        })
+    },
+
+    onEditBlock(handler: (element: BlockElement) => void): DisconnectFn {
+        return onBlockEvent('focusin', handler)
+    },
+
+    onBlurBlock(handler: (element: BlockElement) => void): DisconnectFn {
+        return onBlockEvent('focusout', element => {
+            // Wait for the text area to transform back into a regular block
+            const container = assumeExists(element.closest(Selectors.blockContainer)) as HTMLElement
+            waitForSelectorToExist(`${Selectors.block}#${element.id}`, container).then(handler)
+        })
+    },
+
+    onChangePage(handler: () => void): DisconnectFn {
+        // Only the content changes when switching between pages
+        let stopObservingContent = onSelectorChange(Selectors.mainContent, handler)
+        // The main panel changes when switching between daily notes and regular pages
+        let stopObservingMainPanel = onSelectorChange(Selectors.mainPanel, () => {
+            handler()
+            stopObservingContent()
+            stopObservingContent = onSelectorChange(Selectors.mainContent, handler)
+        })
+
+        return () => {
+            stopObservingContent()
+            stopObservingMainPanel()
+        }
+    },
+}

--- a/src/ts/core/features/vim-mode/roam/roam-highlight.ts
+++ b/src/ts/core/features/vim-mode/roam/roam-highlight.ts
@@ -1,0 +1,25 @@
+import {Selectors} from 'src/core/roam/selectors'
+import {BlockElement} from 'src/core/features/vim-mode/roam/roam-block'
+import {assumeExists} from 'src/core/common/assert'
+
+const highlightedBlocks = (): NodeListOf<BlockElement> =>
+    document.querySelectorAll(`${Selectors.highlight} ${Selectors.block}`)
+
+/**
+ * A "Highlight" is the native roam selection you get when
+ * selecting of blocks.
+ *
+ * Native highlights are reused in order to simulate Vim's "visual mode".
+ *
+ * The generically reusable parts of this should probably move to core/roam
+ */
+export const RoamHighlight = {
+    highlightedBlocks,
+
+    first: (): BlockElement => assumeExists(highlightedBlocks()[0], 'No block is highlighted'),
+
+    last: (): BlockElement => {
+        const blocks = highlightedBlocks()
+        return assumeExists(blocks[blocks.length - 1], 'No block is highlighted')
+    },
+}

--- a/src/ts/core/features/vim-mode/roam/roam-panel.ts
+++ b/src/ts/core/features/vim-mode/roam/roam-panel.ts
@@ -1,0 +1,207 @@
+import {clamp, findLast, last} from 'lodash'
+
+import {Selectors} from 'src/core/roam/selectors'
+import {assumeExists} from 'src/core/common/assert'
+import {BlockElement, BlockId, RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+import {relativeItem} from 'src/core/common/array'
+
+type BlockNavigationState = {
+    panelOrder: Array<PanelId>
+    panels: Map<PanelId, RoamPanel>
+    focusedPanel: PanelIndex
+}
+
+const state: BlockNavigationState = {
+    panelOrder: [],
+    panels: new Map(),
+    focusedPanel: 0,
+}
+
+/**
+ * Use the actual panel elements as a unique identifier. If this doesn't work,
+ * we can tag panel elements with a unique id using css or data attributes
+ */
+type PanelId = PanelElement
+type PanelIndex = number
+type PanelElement = HTMLElement
+
+const PANEL_CSS_CLASS = 'roam-toolkit--panel'
+const PANEL_SELECTOR = `.${PANEL_CSS_CLASS}, ${Selectors.sidebarContent}`
+
+/**
+ * A "Panel" is a viewport that contains blocks. For now, there is just
+ * the Main panel and the Right panel. It is analogous a vim window
+ *
+ * In the future, each page in the right panel could be controlled as it's
+ * own "panel", which might be useful for Matsuchak/Masonry mode
+ *
+ * The generically reusable parts of this should probably move to core/roam
+ */
+export class RoamPanel {
+    private readonly element: PanelElement
+    private _selectedBlockId: BlockId | null
+
+    constructor(element: PanelElement) {
+        this.element = element
+        this._selectedBlockId = null
+    }
+
+    private blocks = (): BlockElement[] => Array.from(this.element.querySelectorAll(Selectors.block))
+
+    private relativeBlockId(blockId: BlockId, blocksToJump: number): BlockId {
+        const blocks = this.blocks()
+        const blockIndex = blocks.findIndex(({id}) => id === blockId)
+        return relativeItem(blocks, blockIndex, blocksToJump).id
+    }
+
+    get selectedBlockId(): BlockId {
+        if (!this._selectedBlockId || !document.getElementById(this._selectedBlockId)) {
+            // Fallback to selecting the first block,
+            // if blockId is not initialized yet, or the block no longer exists
+            const firstBlockId = this.firstBlock().id
+            this.selectBlock(firstBlockId)
+            return firstBlockId
+        }
+
+        return this._selectedBlockId
+    }
+
+    selectedBlock(): RoamBlock {
+        return RoamBlock.get(this.selectedBlockId)
+    }
+
+    selectBlock(blockId: string) {
+        this._selectedBlockId = blockId
+        this.scrollUntilBlockIsVisible(this.selectedBlock().element)
+    }
+
+    selectRelativeBlock(blocksToJump: number) {
+        const block = this.selectedBlock().element
+        this.selectBlock(this.relativeBlockId(block.id, blocksToJump))
+    }
+
+    scrollUntilBlockIsVisible(block: BlockElement) {
+        this.scroll(blockScrollOverflow(block))
+    }
+
+    firstBlock(): BlockElement {
+        return assumeExists(this.element.querySelector(Selectors.block) as BlockElement)
+    }
+
+    lastBlock(): BlockElement {
+        return assumeExists(last(this.blocks()) as BlockElement)
+    }
+
+    select() {
+        state.focusedPanel = state.panelOrder.indexOf(this.element)
+        this.element.scrollIntoView({behavior: 'smooth'})
+    }
+
+    static selected(): RoamPanel {
+        // Select the next closest panel when closing the last panel
+        state.focusedPanel = Math.min(state.focusedPanel, state.panelOrder.length - 1)
+        return RoamPanel.get(state.panelOrder[state.focusedPanel])
+    }
+
+    static fromBlock(blockElement: BlockElement): RoamPanel {
+        return RoamPanel.get(assumeExists(blockElement.closest(PANEL_SELECTOR)) as PanelElement)
+    }
+
+    private static at(panelIndex: PanelIndex): RoamPanel {
+        panelIndex = clamp(panelIndex, 0, state.panelOrder.length - 1)
+        return RoamPanel.get(state.panelOrder[panelIndex])
+    }
+
+    static mainPanel(): RoamPanel {
+        return RoamPanel.at(0)
+    }
+
+    static previousPanel(): RoamPanel {
+        return RoamPanel.at(state.focusedPanel - 1)
+    }
+
+    static nextPanel(): RoamPanel {
+        return RoamPanel.at(state.focusedPanel + 1)
+    }
+
+    static updateSidePanels() {
+        tagPanels()
+        state.panelOrder = Array.from(document.querySelectorAll(PANEL_SELECTOR)) as PanelElement[]
+        state.panels = new Map(state.panelOrder.map(id => [id, RoamPanel.get(id)]))
+    }
+
+    private static get(panelId: PanelId): RoamPanel {
+        // lazily create one if doesn't already exist
+        if (!state.panels.has(panelId)) {
+            state.panels.set(panelId, new RoamPanel(panelId))
+        }
+        return assumeExists(state.panels.get(panelId))
+    }
+
+    scrollAndReselectBlockToStayVisible(scrollPx: number) {
+        this.scroll(scrollPx)
+        this.selectClosestVisibleBlock(this.selectedBlock().element)
+    }
+
+    private scroll(scrollPx: number) {
+        this.element.scrollTop += scrollPx
+    }
+
+    private selectClosestVisibleBlock(block: BlockElement) {
+        const scrollOverflow = blockScrollOverflow(block)
+        if (scrollOverflow < 0) {
+            // Block has gone out of bounds off the top
+            this.selectBlock(this.firstVisibleBlock().id)
+        }
+        if (scrollOverflow > 0) {
+            // Block has gone out of bounds off the bottom
+            this.selectBlock(this.lastVisibleBlock().id)
+        }
+    }
+
+    private firstVisibleBlock(): BlockElement {
+        return assumeExists(this.blocks().find(blockIsVisible), 'Could not find any visible block')
+    }
+
+    private lastVisibleBlock() {
+        return assumeExists(findLast(this.blocks(), blockIsVisible), 'Could not find any visible block')
+    }
+}
+
+/**
+ * Tag the main panel's parent with css, so panel elements can consistently be accessed
+ * using the same selector
+ */
+const tagPanels = () => {
+    const articleElement = assumeExists(document.querySelector(Selectors.mainContent))
+    const mainPanel = assumeExists(articleElement.parentElement)
+    mainPanel.classList.add(PANEL_CSS_CLASS)
+}
+
+// Roughly two lines on either side
+const SCROLL_PADDING_TOP = 100
+const SCROLL_PADDING_BOTTOM = 60
+
+/**
+ * If a block is:
+ * - too far above the viewport, this will be negative
+ * - too far below the viewport, this will be positive
+ * - visible, this will be 0
+ */
+const blockScrollOverflow = (block: BlockElement): number => {
+    const {top, height} = block.getBoundingClientRect()
+
+    const overflowTop = SCROLL_PADDING_TOP - top
+    if (overflowTop > 0) {
+        return -overflowTop
+    }
+
+    const overflowBottom = top + height + SCROLL_PADDING_BOTTOM - window.innerHeight
+    if (overflowBottom > 0) {
+        return overflowBottom
+    }
+
+    return 0
+}
+
+const blockIsVisible = (block: BlockElement): boolean => blockScrollOverflow(block) === 0

--- a/src/ts/core/features/vim-mode/vim-init.ts
+++ b/src/ts/core/features/vim-mode/vim-init.ts
@@ -1,0 +1,51 @@
+import {waitForSelectorToExist} from 'src/core/common/mutation-observer'
+import {Selectors} from 'src/core/roam/selectors'
+import {delay} from 'src/core/common/async'
+
+import {updateBlockNavigationView} from 'src/core/features/vim-mode/vim-view'
+import {RoamPanel} from 'src/core/features/vim-mode/roam/roam-panel'
+import {RoamEvent} from 'src/core/features/vim-mode/roam/roam-event'
+
+/**
+ * Listens to various events like mouse clicks and panel toggling,
+ * in order to synchronize Vim Mode's internal state.
+ */
+export const initializeBlockNavigationMode = async () => {
+    await waitForSelectorToExist(Selectors.mainContent)
+    // Wait for roam to finish setting classes on the block, to
+    // avoid classes getting clobbered
+    await delay(300)
+
+    // Select block when clicked
+    RoamEvent.onEditBlock(blockElement => {
+        RoamPanel.fromBlock(blockElement).select()
+        RoamPanel.selected().selectBlock(blockElement.id)
+        updateBlockNavigationView()
+    })
+
+    // Re-select block after the text area returns to being a regular block
+    RoamEvent.onBlurBlock(updateBlockNavigationView)
+
+    // Re-select main panel block after the closing right panel
+    RoamEvent.onSidebarToggle(isRightPanelOn => {
+        if (!isRightPanelOn) {
+            RoamPanel.mainPanel().select()
+        }
+        RoamPanel.updateSidePanels()
+        updateBlockNavigationView()
+    })
+    // Select first block in right panel when closing pages in right panel
+    RoamEvent.onSidebarChange(() => {
+        RoamPanel.updateSidePanels()
+        updateBlockNavigationView()
+    })
+
+    // Select first block when switching pages
+    RoamEvent.onChangePage(() => {
+        RoamPanel.updateSidePanels()
+        updateBlockNavigationView()
+    })
+
+    RoamPanel.updateSidePanels()
+    updateBlockNavigationView()
+}

--- a/src/ts/core/features/vim-mode/vim-view.ts
+++ b/src/ts/core/features/vim-mode/vim-view.ts
@@ -1,0 +1,58 @@
+import {Mouse} from 'src/core/common/mouse'
+import {isElementVisible} from 'src/core/common/dom'
+import {injectStyle} from 'src/core/common/css'
+import {Selectors} from 'src/core/roam/selectors'
+
+import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+
+/**
+ * Runs side effects such as highlighting the selected block,
+ * in order to update Roam to reflect Vim Mode's internal state
+ */
+
+const BLUR_PIXEL = 'roam-toolkit-block-mode--unfocus-pixel'
+const SELECTED_BLOCK_CSS_CLASS = 'roam-toolkit-block-mode--highlight'
+injectStyle(
+    `
+    .${SELECTED_BLOCK_CSS_CLASS} {
+        background-color: wheat; 
+    }
+    `,
+    'roam-toolkit-block-mode'
+)
+
+export const updateBlockNavigationView = () => {
+    const block = RoamBlock.selected().element
+
+    // Roam.activateBlock focuses the textarea, which prevents holding down j/k.
+    // Visually fake selection using css instead. Then, lazily focus them during manipulation.
+    clearHighlights()
+    block.classList.add(SELECTED_BLOCK_CSS_CLASS)
+
+    viewMoreDailyLogIfPossible()
+
+    return null
+}
+
+const clearHighlights = () => {
+    const priorSelections = document.querySelectorAll(`.${SELECTED_BLOCK_CSS_CLASS}`)
+    priorSelections.forEach(selection => selection.classList.remove(SELECTED_BLOCK_CSS_CLASS))
+}
+
+const viewMoreDailyLogIfPossible = () => {
+    const viewMore = document.querySelector(Selectors.viewMore)
+    if (isElementVisible(viewMore)) {
+        Mouse.hover(viewMore as HTMLElement)
+    }
+}
+
+export const blurEverything = () => {
+    // Clicking a different element also clears popups
+    let blurPixel = document.getElementById(BLUR_PIXEL)
+    if (!blurPixel) {
+        blurPixel = document.createElement('div')
+        blurPixel.id = BLUR_PIXEL
+        document.body.appendChild(blurPixel)
+    }
+    Mouse.leftClick(blurPixel as HTMLElement)
+}

--- a/src/ts/core/features/vim-mode/vim.ts
+++ b/src/ts/core/features/vim-mode/vim.ts
@@ -1,0 +1,71 @@
+import {blurEverything, updateBlockNavigationView} from 'src/core/features/vim-mode/vim-view'
+import {getActiveEditElement} from 'src/core/common/dom'
+import {Selectors} from 'src/core/roam/selectors'
+import {delay, repeatAsync} from 'src/core/common/async'
+import {Shortcut} from 'src/core/settings'
+import {RoamPanel} from 'src/core/features/vim-mode/roam/roam-panel'
+import {Keyboard} from 'src/core/common/keyboard'
+import {RoamHighlight} from 'src/core/features/vim-mode/roam/roam-highlight'
+
+export enum Mode {
+    INSERT,
+    VISUAL,
+    NORMAL,
+}
+
+const getMode = () => {
+    if (getActiveEditElement()) {
+        return Mode.INSERT
+    }
+
+    if (document.querySelector(Selectors.highlight)) {
+        return Mode.VISUAL
+    }
+
+    return Mode.NORMAL
+}
+
+export const returnToNormalMode = async () => {
+    blurEverything()
+    await delay(0)
+    // Clear the native highlight you normally get after blurring a block
+    blurEverything()
+}
+
+type CommandMapper = (key: string, label: string, onPress: (mode: Mode) => void) => Shortcut
+
+const _map = (modes: Mode[]): CommandMapper => (key, label, onPress) => ({
+    type: 'shortcut',
+    id: `blockNavigationMode_${label}`,
+    label,
+    initValue: key,
+    onPress: async () => {
+        const mode = getMode()
+        if (modes.includes(mode)) {
+            await onPress(getMode())
+            updateBlockNavigationView()
+        }
+    },
+})
+
+export const map: CommandMapper = _map([Mode.NORMAL, Mode.VISUAL, Mode.INSERT])
+export const nmap: CommandMapper = _map([Mode.NORMAL])
+export const nimap: CommandMapper = _map([Mode.NORMAL, Mode.INSERT])
+export const nvmap: CommandMapper = _map([Mode.NORMAL, Mode.VISUAL])
+
+export const RoamVim = {
+    async jumpBlocksInFocusedPanel(blocksToJump: number) {
+        const mode = getMode()
+        if (mode === Mode.NORMAL) {
+            RoamPanel.selected().selectRelativeBlock(blocksToJump)
+        }
+        if (mode === Mode.VISUAL) {
+            await repeatAsync(Math.abs(blocksToJump), () =>
+                Keyboard.simulateKey(blocksToJump > 0 ? Keyboard.DOWN_ARROW : Keyboard.UP_ARROW, 0, {shiftKey: true})
+            )
+            RoamPanel.selected().scrollUntilBlockIsVisible(
+                blocksToJump > 0 ? RoamHighlight.last() : RoamHighlight.first()
+            )
+        }
+    },
+}

--- a/src/ts/core/react-hotkeys/key-chord.ts
+++ b/src/ts/core/react-hotkeys/key-chord.ts
@@ -2,7 +2,7 @@ import {Set} from 'immutable'
 
 export type KeyChordString = string
 
-type Modifier = 'alt' | 'shift' | 'control' | 'command'
+type Modifier = 'alt' | 'shift' | 'ctrl' | 'command'
 
 /**
  * A "KeyChord" is a single combination of one or more keys

--- a/src/ts/core/roam/roam.ts
+++ b/src/ts/core/roam/roam.ts
@@ -42,7 +42,7 @@ export const Roam = {
         this.save(action(node))
     },
 
-    async selectBlock(element?: HTMLElement) {
+    async highlight(element?: HTMLElement) {
         if (element) {
             await this.activateBlock(element)
         }
@@ -61,11 +61,11 @@ export const Roam = {
     },
 
     async deleteBlock() {
-        return this.selectBlock().then(() => Keyboard.pressBackspace())
+        return this.highlight().then(() => Keyboard.pressBackspace())
     },
 
     async copyBlock() {
-        await this.selectBlock()
+        await this.highlight()
         document.execCommand('copy')
     },
 
@@ -120,7 +120,7 @@ export const Roam = {
     },
 
     async createDeepestLastDescendant() {
-        await this.selectBlock()
+        await this.highlight()
         await Keyboard.simulateKey(Keyboard.RIGHT_ARROW)
         await Keyboard.pressEnter()
     },

--- a/src/ts/core/roam/selectors.ts
+++ b/src/ts/core/roam/selectors.ts
@@ -9,7 +9,7 @@ export const Selectors = {
     mainPanel: '.roam-body-main',
 
     sidebarContent: '#roam-right-sidebar-content',
-    rightPanel: '#right-sidebar',
+    sidebar: '#right-sidebar',
 
     leftPanel: '.roam-sidebar-container',
 


### PR DESCRIPTION
This is part of a larger change to support vim style navigation (#63)

This actually introduces the vim commands

* Basic navigation
* Insert mode
* Visual mode

It also has abstractions on top of Roam that make it more convenient to implement Vim Mode. The main abstractions that were introduced are:

* Panel - a set of blocks that you navigate between. Analogous to a "Vim Window"
* Roam Events - listeners to roam user actions such as toggling the right panel

I didn't integrate this with `core/roam` yet, since I wanted to get feedback on whether they were the right abstractions first.