### PR TITLE
Vim Mode 5 - Hints for clicking links in blocks

### DIFF
--- a/src/ts/core/features/vim-mode/commands/hint-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/hint-commands.ts
@@ -1,0 +1,18 @@
+import {getHint, HINT_IDS, DEFAULT_HINT_KEYS} from 'src/core/features/vim-mode/hint-view'
+import {nmap} from 'src/core/features/vim-mode/vim'
+import {Mouse} from 'src/core/common/mouse'
+
+export const HintCommands = HINT_IDS.flatMap(n => [
+    nmap(DEFAULT_HINT_KEYS[n], `Click Hint ${n}`, () => {
+        const hint = getHint(n)
+        if (hint) {
+            Mouse.leftClick(hint)
+        }
+    }),
+    nmap(`shift+${DEFAULT_HINT_KEYS[n]}`, `Shift Click Hint ${n}`, () => {
+        const hint = getHint(n)
+        if (hint) {
+            Mouse.leftClick(hint, true)
+        }
+    }),
+])

--- a/src/ts/core/features/vim-mode/hint-view.ts
+++ b/src/ts/core/features/vim-mode/hint-view.ts
@@ -1,0 +1,67 @@
+import {injectStyle} from 'src/core/common/css'
+import {Settings} from 'src/core/settings'
+import {Selectors} from 'src/core/roam/selectors'
+
+export const HINT_IDS = [0, 1, 2, 3, 4, 5]
+export const DEFAULT_HINT_KEYS = ['q', 'w', 'e', 'r', 't', 'f']
+
+const hintKey = async (n: number) =>
+    Settings.get('block_navigation_mode', `blockNavigationMode_Click Hint ${n}`, DEFAULT_HINT_KEYS[n])
+
+const HINT_CSS_CLASS = 'roam-toolkit--hint'
+const hintCssClass = (n: number) => HINT_CSS_CLASS + n
+const HINT_CSS_CLASSES = HINT_IDS.map(hintCssClass)
+
+const hintCss = async (n: number) => {
+    const key = await hintKey(n)
+    return `
+        .${hintCssClass(n)}::after {
+            content: "[${key}]";
+        }
+    `
+}
+
+Promise.all(HINT_IDS.map(hintCss)).then(cssClasses => {
+    injectStyle(
+        cssClasses.join('\n') +
+            `
+        .${HINT_CSS_CLASS}::after {
+            position: relative;
+            top: 5px;
+            display: inline-block;
+            width: 18px;
+            margin-right: -18px;
+            height: 18px;
+            font-size: 10px;
+            font-style: italic;
+            font-weight: bold;
+            color: darkorchid;
+            text-shadow: 1px 1px 0px orange;
+            opacity: 0.7;
+        }
+        .check-container.${HINT_CSS_CLASS}::after {
+            position: absolute;
+            top: 3px;
+        }
+        `,
+        'roam-toolkit-block-mode--hint'
+    )
+})
+
+export const updateBlockNavigationHintView = (block: HTMLElement) => {
+    // button is for reference counts
+    const links = block.querySelectorAll(
+        `${Selectors.link}, ${Selectors.externalLink}, ${Selectors.checkbox}, ${Selectors.button}, ${Selectors.blockReference}`
+    )
+    clearHints()
+    links.forEach((link, i) => {
+        link.classList.add(HINT_CSS_CLASS, hintCssClass(i))
+    })
+}
+
+export const clearHints = () => {
+    const priorHints = document.querySelectorAll(`.${HINT_CSS_CLASS}`)
+    priorHints.forEach(selection => selection.classList.remove(HINT_CSS_CLASS, ...HINT_CSS_CLASSES))
+}
+
+export const getHint = (n: number): HTMLElement | null => document.querySelector(`.${hintCssClass(n)}`)

--- a/src/ts/core/features/vim-mode/index.ts
+++ b/src/ts/core/features/vim-mode/index.ts
@@ -9,6 +9,7 @@ import {PanelCommands} from 'src/core/features/vim-mode/commands/panel-commands'
 import {VisualCommands} from 'src/core/features/vim-mode/commands/visual-commands'
 import {BlockManipulationCommands} from 'src/core/features/vim-mode/commands/block-manipulation-commands'
 import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+import {HintCommands} from 'src/core/features/vim-mode/commands/hint-commands'
 
 export const config: Feature = {
     id: 'block_navigation_mode',
@@ -25,6 +26,7 @@ export const config: Feature = {
         ...ClipboardCommands,
         ...VisualCommands,
         ...BlockManipulationCommands,
+        ...HintCommands,
     ],
 }
 

--- a/src/ts/core/features/vim-mode/vim-view.ts
+++ b/src/ts/core/features/vim-mode/vim-view.ts
@@ -3,6 +3,7 @@ import {isElementVisible} from 'src/core/common/dom'
 import {injectStyle} from 'src/core/common/css'
 import {Selectors} from 'src/core/roam/selectors'
 
+import {updateBlockNavigationHintView} from 'src/core/features/vim-mode/hint-view'
 import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
 
 /**
@@ -28,6 +29,8 @@ export const updateBlockNavigationView = () => {
     // Visually fake selection using css instead. Then, lazily focus them during manipulation.
     clearHighlights()
     block.classList.add(SELECTED_BLOCK_CSS_CLASS)
+
+    updateBlockNavigationHintView(block)
 
     viewMoreDailyLogIfPossible()
 

--- a/src/ts/core/roam/selectors.ts
+++ b/src/ts/core/roam/selectors.ts
@@ -18,4 +18,6 @@ export const Selectors = {
     button: '.bp3-button',
     closeButton: '.bp3-icon-cross',
     viewMore: '.roam-log-preview',
+    checkbox: '.check-container',
+    externalLink: 'a',
 }


### PR DESCRIPTION
This is part of a larger change to support vim style navigation (#63)

This adds the little hint indicators next to links in a block. The UX runs into usability problems for more complex pages, so I think our options are some combination of:

* Discuss the UX further
* Provide an option to opt-out of hints

I personally find the current hint UX useful (I tend to have small blocks), so I'm thinking it might be worth releasing this behind a checkbox like "Enable hints for links" under the vim configuration settings.