### PR TITLE
Vim mode navigation for horizontal sidebar css themes such as Zenith (work in progress)

### DIFF
--- a/src/ts/core/features/vim-mode/roam/roam-panel.ts
+++ b/src/ts/core/features/vim-mode/roam/roam-panel.ts
@@ -26,7 +26,7 @@ type PanelIndex = number
 type PanelElement = HTMLElement
 
 const PANEL_CSS_CLASS = 'roam-toolkit--panel'
-const PANEL_SELECTOR = `.${PANEL_CSS_CLASS}, ${Selectors.sidebarContent}`
+const PANEL_SELECTOR = `.${PANEL_CSS_CLASS}, ${Selectors.sidebarPage}`
 
 /**
  * A "Panel" is a viewport that contains blocks. For now, there is just

--- a/src/ts/core/roam/selectors.ts
+++ b/src/ts/core/roam/selectors.ts
@@ -9,6 +9,7 @@ export const Selectors = {
     mainPanel: '.roam-body-main',
 
     sidebarContent: '#roam-right-sidebar-content',
+    sidebarPage: `#roam-right-sidebar-content > div`,
     sidebar: '#right-sidebar',
 
     leftPanel: '.roam-sidebar-container',


### PR DESCRIPTION
The current `h` and `l` shortcuts don't really with with CSS themes with horizontal layout, such as [Zenith](https://github.com/theianjones/roam-research-themes)

Here is a demo of navigating left / right among sidebar panels:

https://www.youtube.com/watch?v=4t9cy_A3-QI

I wonder if we can detect whether the user is using horizontal mode or not, and adjust the behavior or `h`/`l` accordingly.